### PR TITLE
 Refatora controllers createArticle e getNews, README.MD e app.

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -1,6 +1,8 @@
 # Projeto final: PesquiseNews API RESTfull
 
-Este projeto, intitulado "PesquiseNews", oferece uma solução full-stack para busca e gestão de notícias em tempo real. Aqui está um resumo dos principais pontos abordados:
+Este projeto, intitulado ([PesquiseNews](https://pesquisenews.com.br)), oferece uma solução full-stack para busca e gestão de notícias em tempo real. Aqui está um resumo dos principais pontos abordados:
+
+Para obter informações sobre o frontend do ([PesquiseNews](https://pesquisenews.com.br)), consulte o [README do projeto-pesquisenews-frontend](https://github.com/Evandro-developer/projeto-pesquisenews-frontend).
 
 ## Sumário:
 1. [Fase 2: Back-End](#fase-2-back-end)
@@ -12,56 +14,57 @@ Este projeto, intitulado "PesquiseNews", oferece uma solução full-stack para b
 7. [Configuração do arquivo .env](#Configuração-do-arquivo-.env)
 8. [Endpoints da API](#Endpoints-da-API)
 9. [Tecnologias - Bibliotecas e Frameworks Utilizados](#Tecnologias---Bibliotecas-e-Frameworks-Utilizados)
-10. [Hospedagem no Google Cloud](#hospedagem-no-google-cloud)
-11. [Desenvolvido por](#desenvolvido-por)
-12. [Considerações Finais](#considerações-finais)
-13. [Licença](#licença)
-14. [Código-Fonte](#código-fonte)
-15. [Agradecimentos](#agradecimentos)
+10. [Função de Validação de Artigos](#função-de-validação-de-artigos)
+11. [Hospedagem no Google Cloud](#hospedagem-no-google-cloud)
+12. [Desenvolvido por](#desenvolvido-por)
+13. [Considerações Finais](#considerações-finais)
+14. [Licença](#licença)
+15. [Código-Fonte](#código-fonte)
+16. [Agradecimentos](#agradecimentos)
 
-## <a id="fase-2-back-end"></a>Fase 2: Back-End Etapa única
+## Fase 2: Back-End Etapa única
 
-## <a id="descrição-do-projeto"></a>Descrição do Projeto:
-O projeto é uma etapa final do curso de desenvolvimento web da Tripleten, com foco na implementação de um back-end robusto que se integra a um aplicativo de busca de notícias.
+## Descrição do Projeto:
+O projeto é uma etapa final do curso de desenvolvimento web da [Tripleten](https://tripleten.com/pt-bra/), com foco na implementação de um back-end robusto que se integra a um aplicativo de busca de notícias.
 Esta etapa introduz um back-end robusto para o aplicativo, proporcionando uma experiência full-stack integrada. Esse back-end serve como a espinha dorsal do aplicativo, permitindo a busca e gestão de notícias em tempo real.
 Com a integração à [News API](https://newsapi.org/), é possível acessar artigos e notícias de fontes confiáveis e renomadas ao redor do mundo.
 
-## <a id="back-end---arquitetura-e-características"></a>Back-End - Arquitetura e Características:
-- Tecnologia de Base: O back-end é construído sobre o Node.js, usando o Express.js como framework, permitindo uma construção rápida e eficiente de APIs.
-- Base de Dados: Integrado ao MongoDB, um banco de dados NoSQL, garantindo armazenamento persistente de dados, incluindo perfis de usuários e artigos favoritos.
+## Back-End - Arquitetura e Características:
+- Tecnologia de Base: O back-end é construído sobre o **Node.js**, usando o **Express.js** como framework, permitindo uma construção rápida e eficiente de APIs.
+- Base de Dados: Integrado ao **MongoDB**, um banco de dados NoSQL, garantindo armazenamento persistente de dados, incluindo perfis de usuários e artigos favoritos.
 - Autenticação de Usuários: Implementação de tokens JWT (JSON Web Tokens) para autenticação e proteção de rotas.
 
-## <a id="Middleware e Utilitários"></a>Middleware e Utilitários:
+## Middleware e Utilitários:
 - CORS: Configurado para aceitar solicitações apenas de domínios confiáveis.
 - Helmet: Ajuda na proteção do aplicativo contra vulnerabilidades web comuns.
 - Celebrate: Utilizado para validação de dados e manutenção da integridade dos dados.
 - Logger: Registro personalizado de todas as solicitações e erros, facilitando a depuração e monitoramento.
 
-## <a id="Funcionalidades"></a>Funcionalidades:
+## Funcionalidades:
 - Busca de Notícias: Os usuários podem pesquisar notícias em tempo real de fontes confiáveis e renomadas usando a API externa [News API](https://newsapi.org/).
 - Gestão de Artigos: Os usuários autenticados podem salvar, visualizar e excluir artigos de suas listas favoritas.
 - Autenticação: Processos de registro ("signup") e login ("signin") estão implementados, com validações para garantir a segurança das informações dos usuários.
 - Limitação de Taxa: Implementada para prevenir abuso da API, assegurando uma utilização justa e eficiente.
 - Tratamento de Erros: Middleware personalizado para tratamento de erros, garantindo que os usuários recebam mensagens de erro claras e úteis.
 
-## <a id="Instalação e Execução"></a>Instalação e Execução:
+## Instalação e Execução:
 - Faça o download ou clone este repositório em seu ambiente de desenvolvimento.
 - Abra o terminal e navegue até a pasta raiz do projeto.
 - Execute o comando npm install para instalar as dependências.
 - Configure as variáveis de ambiente no arquivo .env (consulte o exemplo .env.example).
 - Execute o comando npm start para iniciar o servidor.
 
-## <a id="Configuração do arquivo .env"></a>Configuração do arquivo .env:
+## Configuração do arquivo .env:
 O arquivo `.env` é usado para configurar variáveis de ambiente necessárias para o projeto funcionar corretamente. Você deve criar este arquivo na raiz do projeto e definir os seguintes valores:
 - **NODE_ENV**: Define o ambiente de execução do aplicativo (e.g., `development`, `production`).
 - **DEV_JWT_SECRET**: Chave secreta usada para assinar tokens JWT em ambiente de desenvolvimento.
 - **JWT_SECRET**: Chave secreta usada para assinar tokens JWT em ambiente de produção.
 - **PORT**: A porta na qual o servidor será executado (e.g., `3001`).
 - **NEWS_API_KEY**: Sua chave de API para acessar serviços de notícias externas, pode ser solicitada gratuitamente em ([News API](https://newsapi.org/)).
-- **MONGODB_URI**: A URL de conexão com o banco de dados MongoDB(e.g., `ex. myDb`).
+- **MONGODB_URI**: A URL de conexão com o banco de dados **MongoDB**(e.g., `ex. myDb`).
 Para criar o arquivo `.env`, você pode copiar o conteúdo do arquivo `.env.example` e preencher os valores apropriados.
 
-## <a id="Endpoints da API"></a>Endpoints da API:
+## Endpoints da API:
 
 ### Buscar artigos de notícias
 - **Método**: GET
@@ -112,79 +115,115 @@ Em seguida, o artigo é associado ao usuário atualizando a lista de savedArticl
 - **Endpoint**: `/articles/:articleId`
 - **Descrição**: Excluir um artigo específico, usando o ID do artigo.
 
-## <a id="Tecnologias - Bibliotecas e Frameworks Utilizados"></a>Tecnologias - Bibliotecas e Frameworks Utilizados:
+## Tecnologias - Bibliotecas e Frameworks Utilizados:
 
 ### Autenticação:
-- **Tokens JWT**: Utilização de tokens JSON Web Token para autenticar e autorizar usuários de forma segura.
-- **bcryptjs**: Biblioteca para criptografia de senhas e verificação de hashes.
-- **jsonwebtoken**: Implementação de tokens JWT para autenticação.
+- 🔑 **Tokens JWT**: Utilização de tokens JSON Web Token para autenticar e autorizar usuários de forma segura.
+- 🔐 **bcryptjs**: Biblioteca para criptografia de senhas e verificação de hashes.
+- 🛂 **jsonwebtoken**: Implementação de tokens JWT para autenticação.
 
 ### Banco de Dados:
-- **MongoDB**: Um banco de dados NoSQL usado para armazenamento de dados.
-- **mongoose**: Biblioteca ODM (Object Data Modeling) para facilitar a interação com o MongoDB.
+- 🍃 **MongoDB**: Um banco de dados NoSQL usado para armazenamento de dados.
+- 📄 **mongoose**: Biblioteca ODM (Object Data Modeling) para facilitar a interação com o **MongoDB**.
 
 ### Validadores e Middleware:
-- **celebrate**: Middleware para validar entradas de solicitação, utilizado para validação de dados.
-- **joi**: Biblioteca para validação de dados.
-- **validator**: Biblioteca para validação de dados.
-- **cors**: Middleware para habilitar o controle de acesso a recursos de diferentes origens.
+- ✅ **celebrate**: Middleware para validar entradas de solicitação, utilizado para validação de dados.
+- 📋 **joi**: Biblioteca para validação de dados.
+- ✔️ **validator**: Biblioteca para validação de dados.
+- 🔗 **cors**: Middleware para habilitar o controle de acesso a recursos de diferentes origens.
 
 ### Segurança e Monitoramento:
-- **Helmet**: Ajuda na proteção do aplicativo contra vulnerabilidades web comuns.
+- ⛑️ **Helmet**: Ajuda na proteção do aplicativo contra vulnerabilidades web comuns.
 - **Express-rate-limit**: Middleware para limitar a taxa de solicitações à API.
 
 ### Registro e Debugging:
-- **Logger**: Registro personalizado de todas as solicitações e erros, facilitando a depuração e monitoramento.
-- **Winston**: Bibliotecas para criar e gerenciar registros de logs no aplicativo.
-- **express-winston**: Bibliotecas para criar e gerenciar registros de logs no aplicativo.
+- 📜 **Logger**: Registro personalizado de todas as solicitações e erros, facilitando a depuração e monitoramento.
+- 🖊️ **Winston**: Bibliotecas para criar e gerenciar registros de logs no aplicativo.
+- 📒 **express-winston**: Bibliotecas para criar e gerenciar registros de logs no aplicativo.
 
 ### Outros:
-- **dotenv**: Biblioteca para carregar variáveis de ambiente a partir de um arquivo .env.
-- **eslint**: Ferramenta de linting para garantir a qualidade do código JavaScript.
-- **eslint-config-airbnb-base**: Configuração do ESLint seguindo as regras do Airbnb para código JavaScript.
-- **Express**: Um framework Node.js para construção de aplicativos web e APIs.
-- **newsapi**: Uma biblioteca para acessar serviços de notícias externas da ([News API](https://newsapi.org/)).
-- **Node.js**: Uma plataforma de runtime que permite a execução de código JavaScript no servidor.
+- 🌍 **dotenv**: Biblioteca para carregar variáveis de ambiente a partir de um arquivo .env.
+- 🚫 **eslint**: Ferramenta de linting para garantir a qualidade do código JavaScript.
+- 📏 **eslint-config-airbnb-base**: Configuração do ESLint seguindo as regras do Airbnb para código JavaScript.
+- 🛤️ **Express**: Um framework **Node.js** para construção de aplicativos web e APIs.
+- 🟩 **Node.js**: Uma plataforma de runtime que permite a execução de código JavaScript no servidor.
 
-## <a id="Hospedagem no Google Cloud"></a>Hospedagem no Google Cloud:
-Este projeto será hospedado no Google Cloud na Fase 3 do projeto "PesquiseNews" para que você possa acessá-lo online. O backend do aplicativo será implantado em uma instância do Google Compute Engine, enquanto o frontend estará hospedado no Google Cloud Storage. Isso permitirá experimentar o aplicativo sem precisar configurar nada localmente, aproveitando a infraestrutura e serviços de nuvem escaláveis. O GCP proporciona uma solução confiável e eficiente para hospedagem de aplicações, permitindo a nossa API ter alta disponibilidade e baixa latência.
+Da arquitetura do backend e sua integração com serviços de frontend. O projeto reforça a importância de criar soluções seguras, escaláveis e eficientes para atender às demandas dos usuários.
 
-Agradecemos por visitar o aplicativo hospedado no Google Cloud!
+## Função de Validação de Artigos:
+Uma das principais funcionalidades introduzidas no backend é a validação de artigos antes de sua inclusão ou exibição. Esta função, denominada **isValidArticle**, garante que os artigos que estão sendo processados pelo nosso sistema não contêm valores indesejados ou datas inválidas.
 
-## <a id="Desenvolvido por"></a>Desenvolvido por:
+### Descrição da Funcionalidade:
+A função **isValidArticle** serve para verificar a integridade e relevância dos artigos. Ela se concentra em duas verificações principais:
 
-### **Evandro de Melo Oliveira**
+### Verificação de Conteúdo Indesejado:
+A função verifica se os artigos contêm quaisquer conteúdos indesejados, como links removidos, valores nulos ou placeholders comuns que podem indicar um artigo comprometido ou incompleto. Esta verificação é essencial para manter a integridade do conteúdo exibido aos usuários.
+
+### Verificação de Data:
+Outra verificação crucial é para a data de publicação do artigo. Se um artigo possui uma data que coincide com "1970-01-01T00:00:00Z", isso pode indicar uma data inválida ou um placeholder, sendo assim, o artigo é considerado inválido.
+
+A função retorna true se o artigo for válido (não contém conteúdo indesejado ou data inválida) e false caso contrário. Esta validação é crucial para garantir que o conteúdo apresentado aos usuários seja de alta qualidade e relevância, e que os artigos comprometidos ou irrelevantes não sejam processados inadvertidamente.
+
+**const isValidArticle** = (article) => {
+  // Lista de valores indesejados
+  const undesiredValues = [null, "[Removed]", "https://removed.com"];
+
+  // Verifica se algum valor indesejado está presente em quaisquer propriedades dos artigos
+  const hasUndesiredContent = [
+    "title",
+    "description",
+    "source",
+    "url",
+    "urlToImage",
+  ].some((prop) => undesiredValues.includes(article[prop]));
+
+  // Verifica se tem uma data inválida
+  const hasInvalidDate = article.publishedAt === "1970-01-01T00:00:00Z";
+
+  return !(hasUndesiredContent || hasInvalidDate);
+};
+
+Recomendamos que os desenvolvedores implementem sempre verificações como esta ao lidar com conteúdo de terceiros ou dados de APIs externas, garantindo assim a segurança, integridade e a melhor experiência do usuário.
+
+## Hospedagem no Google Cloud:
+Este projeto foi hospedado no **Google Cloud** na Fase 3 do projeto ([PesquiseNews](https://pesquisenews.com.br)) para que você possa acessá-lo online. O backend do aplicativo implantado em uma instância do Google Compute Engine, enquanto o frontend no **Google Cloud Storage**. Isso permite experimentar o aplicativo sem precisar configurar nada localmente, aproveitando a infraestrutura e serviços de nuvem escaláveis. O GCP proporciona uma solução confiável e eficiente para hospedagem de aplicações, permitindo a nossa API ter alta disponibilidade e baixa latência.
+
+Agradecemos por visitar o aplicativo hospedado no **Google Cloud**!
+
+## Desenvolvido por:
+
+### **Evandro M Oliveira**
 **Profissão**: Desenvolvedor Web.
-**Especialidade**: Domínio em Node.js, Express, otimização de consultas em MongoDB e React.
+**Especialidade**: Domínio em **Node.js**, **Express.js**, otimização de consultas em **MongoDB** e **React**.
 **Formação**: Atualmente cursando Ciência de Dados e um Boot Camp em Análise de Dados. Também aprofundando conhecimentos em Design de UI/UX.
-**Contribuição ao projeto**: Desenvolvimento e hospedagem do back-end na Google Cloud.
+**Contribuição ao projeto**: Desenvolvimento e hospedagem do back-end na **Google Cloud**.
 
-### **Tripleten**
+### [**Tripleten**](https://tripleten.com/pt-bra/)
 **Contribuição ao projeto**: Design e experiência do usuário.
 
-## <a id="Considerações Finais"></a>Considerações Finais:
-A implementação do back-end para o "PesquiseNews" não apenas eleva a funcionalidade do aplicativo, mas também exemplifica a integração eficiente de diversas tecnologias e bibliotecas para criar uma solução full-stack. Seja você um entusiasta de notícias ou apenas um usuário curioso, convidamos você a experimentar este aplicativo e mergulhar no mundo das notícias em tempo real.
+## Considerações Finais:
+A implementação do back-end para o ([PesquiseNews](https://pesquisenews.com.br)) não apenas eleva a funcionalidade do aplicativo, mas também exemplifica a integração eficiente de diversas tecnologias e bibliotecas para criar uma solução full-stack. Seja você um entusiasta de notícias ou apenas um usuário curioso, convidamos você a experimentar este aplicativo e mergulhar no mundo das notícias em tempo real.
 Agradecemos a todos que contribuíram para o sucesso deste projeto. A implementação da API RESTfull marcou uma grande etapa em minha jornada de aprendizado, permitindo compreender os intricados detalhes do desenvolvimento back-end. Espero continuar aprimorando minhas habilidades e trazer ainda mais inovações no futuro.
 
-## <a id="Licença"></a>Licença:
+## Licença:
 Este projeto é open source e está licenciado sob a Licença MIT. Isso significa que você é livre para usar, copiar, modificar e distribuir o projeto, desde que forneça os devidos créditos aos autores originais e siga os termos da licença.
 
 O licenciamento sob a Licença MIT é uma maneira de permitir que outros desenvolvedores usem e contribuam para o projeto, enquanto também protege os direitos dos autores originais. Se você decidir usar ou modificar este projeto, lembre-se de incluir a licença original e dar crédito aos autores.
 
 A Licença MIT é uma licença permissiva, o que significa que ela não coloca muitas restrições sobre como você pode usar ou redistribuir o software. No entanto, ela vem com uma isenção de responsabilidade importante, que basicamente diz que o software é fornecido "como está", sem qualquer tipo de garantia.
 
-## <a id="Código-Fonte"></a>Código-Fonte:
+## Código-Fonte:
 Acesse o [repositório do projeto](https://github.com/Evandro-developer/projeto-pesquisenews-backend) no GitHub para consultar o código-fonte completo e pode ser encontrado em nosso repositório no GitHub. Sinta-se à vontade para explorá-lo, fazer fork e contribuir com melhorias ou correções.
 
 Se você estiver interessado em contribuir ou simplesmente quiser dar uma olhada, fique à vontade para visitar o repositório. Qualquer feedback ou contribuição é muito apreciado.
 
-## <a id=Agradecimentos></a>Agradecimentos:
-Agradecemos por acompanhar o desenvolvimento deste projeto, aos coordenadores, tutores e revisores da Tripleten por me guiarem durante este curso. Também gostaria de agradecer a toda a comunidade de desenvolvimento por fornecer recursos e ferramentas valiosos que facilitaram minha jornada de aprendizado.
+## Agradecimentos:
+Agradecemos por acompanhar o desenvolvimento deste projeto, aos coordenadores, tutores e revisores da [Tripleten](https://tripleten.com/pt-bra/) por me guiarem durante este curso. Também gostaria de agradecer a toda a comunidade de desenvolvimento por fornecer recursos e ferramentas valiosos que facilitaram minha jornada de aprendizado.
 
 Um agradecimento especial a todos que contribuíram para este projeto, seja por meio de código, design, testes ou simplesmente dando feedback. Cada contribuição fez a diferença e ajudou a moldar este projeto no que ele é hoje.
 
 Além disso, gostaria de agradecer à comunidade de desenvolvedores e aos muitos recursos online que tornaram possível aprender e implementar as várias tecnologias e bibliotecas usadas neste projeto. A jornada de aprendizado nunca termina, e sou grato por todas as oportunidades de aprendizado que surgiram ao longo do caminho.
 
-Finalmente, obrigado a você, leitor, por se interessar e gastar seu tempo aprendendo sobre o projeto PesquiseNews. Esperamos que você ache o projeto útil e talvez até seja inspirado a criar algo semelhante ou a contribuir para este projeto. Juntos, podemos continuar a expandir e melhorar o mundo do desenvolvimento web.
+Finalmente, obrigado a você, leitor, por se interessar e gastar seu tempo aprendendo sobre o projeto ([PesquiseNews](https://pesquisenews.com.br)). Esperamos que você ache o projeto útil e talvez até seja inspirado a criar algo semelhante ou a contribuir para este projeto. Juntos, podemos continuar a expandir e melhorar o mundo do desenvolvimento web.
 
 Obrigado.

--- a/README.MD
+++ b/README.MD
@@ -186,3 +186,5 @@ Um agradecimento especial a todos que contribuíram para este projeto, seja por 
 Além disso, gostaria de agradecer à comunidade de desenvolvedores e aos muitos recursos online que tornaram possível aprender e implementar as várias tecnologias e bibliotecas usadas neste projeto. A jornada de aprendizado nunca termina, e sou grato por todas as oportunidades de aprendizado que surgiram ao longo do caminho.
 
 Finalmente, obrigado a você, leitor, por se interessar e gastar seu tempo aprendendo sobre o projeto PesquiseNews. Esperamos que você ache o projeto útil e talvez até seja inspirado a criar algo semelhante ou a contribuir para este projeto. Juntos, podemos continuar a expandir e melhorar o mundo do desenvolvimento web.
+
+Obrigado.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "projeto-pesquisenews-backend",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "main": "app.js",
   "scripts": {
     "lint": "eslint . --fix",
@@ -8,8 +8,50 @@
     "dev": "nodemon app.js",
     "test": "jest"
   },
-  "keywords": [],
-  "author": "Evandro de Melo Oliveira",
+  "engines": {
+    "node": ">=14.0.0",
+    "npm": ">=7.0.0"
+  },
+  "parserOptions": {
+    "ecmaVersion": 2020
+  },
+  "keywords": [
+    "agile",
+    "api",
+    "authentication",
+    "backend",
+    "content-delivery",
+    "current-events",
+    "database",
+    "environment",
+    "express",
+    "filtering",
+    "HTTP",
+    "information-retrieval",
+    "jsonwebtoken",
+    "logging",
+    "middleware",
+    "mongoose",
+    "news",
+    "news-aggregator",
+    "newsapi",
+    "nodejs",
+    "open-source",
+    "optimization",
+    "rate-limit",
+    "research",
+    "RESTful",
+    "search",
+    "secure",
+    "security",
+    "validation"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Evandro-developer/projeto-pesquisenews-backend.git"
+  },
+  "author": "Evandro M Oliveira",
+  "description": "PesquiseNews API RESTfull.",
   "license": "ISC",
   "devDependencies": {
     "eslint": "^8.45.0",
@@ -31,7 +73,6 @@
     "joi": "^17.9.2",
     "jsonwebtoken": "^9.0.1",
     "mongoose": "^7.4.3",
-    "newsapi": "^2.4.1",
     "regenerator-runtime": "^0.14.0",
     "validator": "^13.11.0",
     "winston": "^3.10.0"


### PR DESCRIPTION
As chave apiKey deve ser obtida em https://newsapi.org/ e passada para .env como NEWS_API_KEY, além de NODE_ENV -DEV_JWT_SECRET, JWT_SECRET, PORT e MONGODB_URI.
Foram refatorados os controllers createArticle e getNews. O primeiro para incluir ownerId e o segundo para formatar a resposta de acordo com o schema article.
O README.MD foi aprimorado para facilitar a leitura.
Em app organizamos a sequência dos endpoints para evitar solicitações com autorização desnecessárias, antes do usuário logar. A  busca de notícias não precisa de registro.
